### PR TITLE
Finished checking off meters

### DIFF
--- a/Assets/Scripts/GlobalControls.cs
+++ b/Assets/Scripts/GlobalControls.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public static class GlobalControls
 {
+    private static int noStoredWaterTime = 3;
     /* poopTimeLeft and waterTimeLeft should be set to initial values after the quake,
        if the player has stored water, they should have the default 12 hours on the water meter, if not
        only 3; then the meters should be enabled in this script*/
@@ -14,7 +15,7 @@ public static class GlobalControls
     private static bool poopTaskCompleted = false;
     private static bool waterTaskCompleted = false;
 
-    private static int noStoredWaterTime = 3;
+    
 
     public static bool MetersEnabled
     {

--- a/Assets/Scripts/GlobalControls.cs
+++ b/Assets/Scripts/GlobalControls.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public static class GlobalControls
 {
-    /* poopTimeLeft and waterTimeLeft should be set to intial values after the quake,
+    /* poopTimeLeft and waterTimeLeft should be set to initial values after the quake,
        if the player has stored water, they should have the default 12 hours on the water meter, if not
        only 3; then the meters should be enabled in this script*/
     // metersEnabled is currently set to true for testing purposes

--- a/Assets/Scripts/MeterControl.cs
+++ b/Assets/Scripts/MeterControl.cs
@@ -24,10 +24,16 @@ public class MeterControl : MonoBehaviour
         waterTimeLeft = GlobalControls.WaterTimeLeft;
         if (GlobalControls.MetersEnabled && !isStrategicMap)
         {
-            poopTimeLeft--;
-            waterTimeLeft--;
-            GlobalControls.PoopTimeLeft = poopTimeLeft;
-            GlobalControls.WaterTimeLeft = waterTimeLeft;
+            if (!GlobalControls.PoopTaskCompleted)
+            {
+                poopTimeLeft--;
+                GlobalControls.PoopTimeLeft = poopTimeLeft;
+            }
+            if (!GlobalControls.WaterTaskCompleted)
+            {
+                waterTimeLeft--;
+                GlobalControls.WaterTimeLeft = waterTimeLeft;
+            }
         }
         PoopTaskCheck.SetActive(GlobalControls.PoopTaskCompleted);
         WaterTaskCheck.SetActive(GlobalControls.WaterTaskCompleted);


### PR DESCRIPTION
Fixed bug to allow the user to (for testing purposes, latrine and water to be implemented later) check off the meters and stop them from ticking down.

Check off the meters by pressing 'p' for poop meter or 'o' for water meter on the keyboard.